### PR TITLE
Notify bar fix

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ default_envs = CUSTOMBOARD
 platform = espressif32
 framework = arduino
 version = 0.1.4
-revision = 19
+revision = 20
 monitor_speed = 115200
 monitor_rts = 0
 monitor_dtr = 0
@@ -26,7 +26,7 @@ monitor_filters =
   esp32_exception_decoder
 extra_scripts = pre:prebuild.py
 build_flags = 
-	-D CORE_DEBUG_LEVEL=0
+	-D CORE_DEBUG_LEVEL=5
 	-D USE_LINE_BUFFER=1
 	-D DISABLE_RADIO=1
 	-D GPS_BAUDRATE=9600

--- a/src/gui/events/notify_bar.h
+++ b/src/gui/events/notify_bar.h
@@ -58,22 +58,46 @@ static void update_fix_mode(lv_event_t *event)
 }
 
 /**
+ * @brief Temperature update event
+ *
+ */
+static void update_temp(lv_event_t *event)
+{
+    lv_obj_t *temp = lv_event_get_target(event);
+    lv_label_set_text_fmt(temp, "%02d\xC2\xB0", (uint8_t)(bme.readTemperature()));
+}
+
+/**
+ * @brief Time update event
+ *
+ */
+static void update_time(lv_event_t *event)
+{
+    lv_obj_t *time = lv_event_get_target(event);
+    // UTC Time
+    utc = now();
+    // Local Time
+    local = CE.toLocal(utc);
+    lv_label_set_text_fmt(time, "%02d:%02d:%02d", hour(local), minute(local), second(local));
+}
+
+/**
+ * @brief Update satellite count event
+ *
+ */
+static void update_gps_count(lv_event_t *event)
+{
+    lv_obj_t *count = lv_event_get_target(event);
+    lv_label_set_text_fmt(count, LV_SYMBOL_GPS "%2d", GPS.satellites.value());
+}
+
+/**
  * @brief Update notify bar info timer
  *
  */
 void update_notify_bar(lv_timer_t *t)
 {
-    // UTC Time
-    utc = now();
-    // Local Time
-    local = CE.toLocal(utc);
-    lv_label_set_text_fmt(gps_time, "%02d:%02d:%02d", hour(local), minute(local), second(local));
-
-    if (atoi(fix_mode.value()) != fix_mode_old)
-    {
-        lv_event_send(gps_fix_mode, LV_EVENT_VALUE_CHANGED, NULL);
-        fix_mode_old = atoi(fix_mode.value());
-    }
+    lv_event_send(gps_time, LV_EVENT_VALUE_CHANGED, NULL);
 
     switch (atoi(fix.value()))
     {
@@ -93,6 +117,12 @@ void update_notify_bar(lv_timer_t *t)
         break;
     }
 
+    if (atoi(fix_mode.value()) != fix_mode_old)
+    {
+        lv_event_send(gps_fix_mode, LV_EVENT_VALUE_CHANGED, NULL);
+        fix_mode_old = atoi(fix_mode.value());
+    }
+
     batt_level = battery_read();
     if (batt_level != batt_level_old)
     {
@@ -102,14 +132,14 @@ void update_notify_bar(lv_timer_t *t)
 
     if (GPS.satellites.value() != sat_count_old)
     {
-        lv_label_set_text_fmt(gps_count, LV_SYMBOL_GPS "%2d", GPS.satellites.value());
+        lv_event_send(gps_count, LV_EVENT_VALUE_CHANGED, NULL);
         sat_count_old = GPS.satellites.value();
     }
 
 #ifdef ENABLE_BME
     if ((uint8_t)(bme.readTemperature()) != temp_old)
     {
-        lv_label_set_text_fmt(temp, "%02d\xC2\xB0", (uint8_t)(bme.readTemperature()));
+        lv_event_send(temp, LV_EVENT_VALUE_CHANGED, NULL);
         temp_old = (uint8_t)(bme.readTemperature());
     }
 #endif

--- a/src/gui/screens-lvgl/notify_bar.h
+++ b/src/gui/screens-lvgl/notify_bar.h
@@ -67,10 +67,12 @@ void create_notify_bar()
     else
         lv_label_set_text(sdcard, " ");
 
+#ifdef ENABLE_BME
     temp = lv_label_create(lv_scr_act());
     lv_obj_set_size(temp, 50, 20);
     lv_obj_set_pos(temp, TFT_WIDTH - 145, 2);
     lv_label_set_text(temp, "--\xC2\xB0");
+#endif
 
     gps_time = lv_label_create(lv_scr_act());
     lv_obj_set_size(gps_time, 100, 20);

--- a/src/gui/screens-lvgl/notify_bar.h
+++ b/src/gui/screens-lvgl/notify_bar.h
@@ -58,6 +58,7 @@ void create_notify_bar()
     gps_count = lv_label_create(lv_scr_act());
     lv_obj_set_size(gps_count, 50, 20);
     lv_obj_set_pos(gps_count, TFT_WIDTH - 98, 2);
+    lv_obj_add_event_cb(gps_count, update_gps_count, LV_EVENT_VALUE_CHANGED, NULL);
 
     sdcard = lv_label_create(lv_scr_act());
     lv_obj_set_size(sdcard, 20, 20);
@@ -72,12 +73,15 @@ void create_notify_bar()
     lv_obj_set_size(temp, 50, 20);
     lv_obj_set_pos(temp, TFT_WIDTH - 145, 2);
     lv_label_set_text(temp, "--\xC2\xB0");
+    lv_obj_add_event_cb(temp, update_temp, LV_EVENT_VALUE_CHANGED, NULL);
 #endif
 
     gps_time = lv_label_create(lv_scr_act());
     lv_obj_set_size(gps_time, 100, 20);
     lv_obj_set_pos(gps_time, 0, 0);
     lv_obj_set_style_text_font(gps_time, &lv_font_montserrat_20, 0);
+    lv_label_set_text_fmt(gps_time, "%02d:%02d:%02d", hour(local), minute(local), second(local));
+    lv_obj_add_event_cb(gps_time, update_time, LV_EVENT_VALUE_CHANGED, NULL);
 
     lv_timer_t *timer_notify_bar = lv_timer_create(update_notify_bar, UPDATE_NOTIFY_PERIOD, NULL);
     lv_timer_ready(timer_notify_bar);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,14 +89,4 @@ void loop()
 #endif
   lv_timer_handler();
   delayMicroseconds(5);
-//   while (gps->available() > 0)
-//   {
-// #ifdef OUTPUT_NMEA
-//     {
-//       debug->write(gps->read());
-//     }
-// #else
-//     GPS.encode(gps->read());
-// #endif
-//  }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,9 +73,9 @@ void setup()
   splash_scr();
   init_tasks();
 
-  // lv_scr_load(searchSat);
-  lv_scr_load(mainScreen);
-  create_notify_bar();
+  lv_scr_load(searchSat);
+  //lv_scr_load(mainScreen);
+  //create_notify_bar();
 }
 
 /**


### PR DESCRIPTION
## Description

Notify bar items fixed

## Related Issues

If Satellite search screen is not called at program startup when signal is fixed some labels appears overlapped

## Tests

I added the following tests:

Works well if Satellite search screen is called at program startup.