### PR TITLE
Power off support

### DIFF
--- a/lib/cli/cli.cpp
+++ b/lib/cli/cli.cpp
@@ -28,9 +28,7 @@ void wcli_reboot(char *args, Stream *response)
 }
 
 void wcli_poweroff(char *args, Stream *response) {
-  // powerOffPeripherals();
-  // powerDeepSeep();
-  powerLightSleep();
+  deviceSuspend();
 }
 
 void wcli_info(char *args, Stream *response)

--- a/lib/power/power.cpp
+++ b/lib/power/power.cpp
@@ -52,22 +52,49 @@ void powerLightSleep()
   esp_light_sleep_start();
 }
 
+void powerOffScreen()
+{
+#ifdef TDECK_ESP32S3
+  // LilyGo T-Deck control backlight chip has 16 levels of adjustment range
+  // for (int i = 16; i > 0; --i) {
+  //   setBrightness(i);
+  //   delay(30);
+  // }
+  tft.setBrightness(0);
+  // tft.getPanel()->setSleep(true);
+  // TODO: we could need a complete panel power off?
+#else
+  setBrightness(0);
+#endif
+}
+
+/**
+ * @brief Core light suspend and TFT off
+ */
+void deviceSuspend()
+{
+  int brightness = tft.getBrightness();
+  powerOffScreen();
+  powerLightSleep();
+  tft.setBrightness(brightness);
+}
+
+/**
+ * @brief Power off peripherals and deepsleep
+ */
+void deviceShutdown()
+{
+  powerOffPeripherals();
+  powerDeepSeep();
+}
+
 /**
  * @brief Power off peripherals devices
  */
 void powerOffPeripherals()
 {
-#ifdef TDECK_ESP32S3
-  // LilyGo T-Deck control backlight chip has 16 levels of adjustment range
-  for (int i = 16; i > 0; --i) {
-    setBrightness(i);
-    delay(30);
-  }
-#endif
-
-  delay(1000);
-
-  tft.getPanel()->setSleep(true);
+  powerOffScreen();
+  tft.getPanel()->setSleep(true); // sounds that it is not working
   tft.writecommand(0x10);  // set display enter sleep mode
   SPI.end();
   Wire.end();

--- a/lib/power/power.hpp
+++ b/lib/power/power.hpp
@@ -21,6 +21,9 @@ void powerDeepSeep();
 void powerLightSleepTimer(int millis);
 void powerLightSleep();
 void powerOffPeripherals();
+void powerOffScreen();
+void deviceSuspend();
+void deviceShutdown();
 void powerOn();
 
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -47,6 +47,7 @@ lib_deps =
   hpsaturn/EasyPreferences@^0.1.2
   ; hpsaturn/ESP32 Wifi CLI@^0.3.0
   https://github.com/hpsaturn/esp32-wifi-cli.git#av/fix_nmcli_up_issue
+  vortigont/ESPAsyncButton@^1.2.1
   kubafilinger/AsyncTCP@^1.1.1
   esphome/ESPAsyncWebServer-esphome@^2.1.0
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include <AsyncTCP.h>
 #include <ESPAsyncWebServer.h>
 #include <Timezone.h>
+#include <espasyncbutton.hpp>
 
 // Hardware includes
 #include "hal.hpp"
@@ -49,6 +50,20 @@ extern xSemaphoreHandle gpsMutex;
 #include "settings.hpp"
 #include "lvglSetup.hpp"
 #include "tasks.hpp"
+
+AsyncEventButton b1(GPIO_NUM_0, LOW);
+
+uint32_t deviceSuspendCount = 0;
+
+void on_multi_click(int32_t counter){
+  Serial.println("device suspend..");
+  deviceSuspendCount = 300;
+}
+
+void on_long_press(){
+  Serial.println("device shutdown..");
+  deviceSuspendCount = 1000;
+}
 
 /**
  * @brief Setup
@@ -153,6 +168,13 @@ void setup()
     tileSize = RENDER_TILE_SIZE;
     generateRenderMap();
   }
+
+  if(WiFi.getMode() == WIFI_OFF)
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+  b1.begin();
+  b1.onMultiClick(on_multi_click);
+  b1.onLongPress(on_long_press);
+  b1.enable();
 }
 
 /**
@@ -166,4 +188,7 @@ void loop()
     lv_timer_handler();
     vTaskDelay(pdMS_TO_TICKS(TASK_SLEEP_PERIOD_MS));
   }
+  if (deviceSuspendCount == 500) deviceShutdown();
+  if (deviceSuspendCount == 1) deviceSuspend();
+  if (deviceSuspendCount > 0 ) deviceSuspendCount--;
 }


### PR DESCRIPTION
## Summary

Initial support and improvements for T-Deck device using the trackball button for light and deep sleep actions. 

## Features

- [x] Added asyn button library that uses FreeRTOS system events
- [x] Added new isolated methods on power lib
- [x] Set light sleed for test on the CLI command 
- [x] Button actions: double click for light suspend. Long press for deep-sleep 

## Knew issues

- [ ] The double click and long click don't work in the map
- [ ] The GPS in deep-sleep keeps on. It's good from a different point of view
- [ ] We need understand the TFT suspend for this panel. Now only set brightness to 0
- [ ] Incompatibility with the original setbrightness of IceNav
  