### PR TITLE
Fix issue 212 cli defaults

### DIFF
--- a/lib/cli/cli.cpp
+++ b/lib/cli/cli.cpp
@@ -101,6 +101,39 @@ void wcli_scshot(char *args, Stream *response)
   }
 }
 
+/**
+ * @brief list of user preference key. This depends of EasyPreferences manifest.
+ * @author @Hpsaturn. Method migrated from CanAirIO project
+ */
+void wcli_klist(char *args, Stream *response) {
+  Pair<String, String> operands = wcli.parseCommand(args);
+  String opt = operands.first();
+  response->printf("\n%11s \t%s \t%s \r\n", "KEYNAME", "DEFINED", "VALUE");
+  response->printf("\n%11s \t%s \t%s \r\n", "=======", "=======", "=====");
+
+  for (int i = PKEYS::KUSER+1; i < PKEYS::KCOUNT; i++) {
+    String key = cfg.getKey((CONFKEYS)i);
+    bool isDefined = cfg.isKey(key);
+    String defined = isDefined ? "custom " : "default";
+    String value = "";
+    if (isDefined) value = cfg.getValue(key);
+    response->printf("%11s \t%s \t%s \r\n", key, defined.c_str(), value.c_str());
+  }
+}
+
+/**
+ * @brief set an user preference key. This depends of EasyPreferences manifest.
+ * @author @Hpsaturn. Method migrated from CanAirIO project
+ */
+void wcli_kset(char *args, Stream *response) {
+  Pair<String, String> operands = wcli.parseCommand(args);
+  String key = operands.first();
+  String v = operands.second();
+  if(cfg.saveAuto(key,v)){
+    response->printf("saved key %s\t: %s\r\n", key, v);
+  }
+}
+
 void wcli_waypoint(char *args, Stream *response)
 {
   Pair<String, String> operands = wcli.parseCommand(args);
@@ -280,7 +313,6 @@ void wcli_settings(char *args, Stream *response)
   }
 }
 
-
 void wcli_webfile(char *args, Stream *response)
 {
   Pair<String, String> operands = wcli.parseCommand(args);
@@ -327,6 +359,8 @@ void initShell(){
   wcli.add("waypoint", &wcli_waypoint, "\twaypoint utilities");
   wcli.add("settings", &wcli_settings, "\tdevice settings");
   wcli.add("webfile", &wcli_webfile, "\tenable/disable Web file server");
+  wcli.add("klist", &wcli_klist, "\t\tlist of user extra preferences");
+  wcli.add("kset", &wcli_kset, "\t\tset an user extra preference");
   wcli.begin("IceNav");
 }
 

--- a/lib/gps/gps.cpp
+++ b/lib/gps/gps.cpp
@@ -132,6 +132,11 @@ double getLat()
 {
   if (GPS.location.isValid())
     return GPS.location.lat();
+  else if (cfg.getDouble(PKEYS::KLAT_DFL,0.0) != 0.0)
+  {
+    log_i("getLat: %02f\r\n",cfg.getDouble(PKEYS::KLAT_DFL,0.0));
+    return cfg.getDouble(PKEYS::KLAT_DFL,0.0);
+  }
   else
   {
 #ifdef DEFAULT_LAT
@@ -150,6 +155,11 @@ double getLon()
 {
   if (GPS.location.isValid())
     return GPS.location.lng();
+  else if (cfg.getDouble(PKEYS::KLON_DFL,0.0) != 0.0)
+  {
+    log_i("getLon: %02f\r\n",cfg.getDouble(PKEYS::KLON_DFL,0.0));
+    return cfg.getDouble(PKEYS::KLON_DFL,0.0);
+  }
   else
   {
 #ifdef DEFAULT_LON

--- a/lib/gps/gps.cpp
+++ b/lib/gps/gps.cpp
@@ -134,7 +134,7 @@ double getLat()
     return GPS.location.lat();
   else if (cfg.getDouble(PKEYS::KLAT_DFL,0.0) != 0.0)
   {
-    log_i("getLat: %02f\r\n",cfg.getDouble(PKEYS::KLAT_DFL,0.0));
+    log_v("getLat: %02f\r\n",cfg.getDouble(PKEYS::KLAT_DFL,0.0));
     return cfg.getDouble(PKEYS::KLAT_DFL,0.0);
   }
   else
@@ -157,7 +157,7 @@ double getLon()
     return GPS.location.lng();
   else if (cfg.getDouble(PKEYS::KLON_DFL,0.0) != 0.0)
   {
-    log_i("getLon: %02f\r\n",cfg.getDouble(PKEYS::KLON_DFL,0.0));
+    log_v("getLon: %02f\r\n",cfg.getDouble(PKEYS::KLON_DFL,0.0));
     return cfg.getDouble(PKEYS::KLON_DFL,0.0);
   }
   else

--- a/lib/preferences/preferences-keys.h
+++ b/lib/preferences/preferences-keys.h
@@ -23,6 +23,6 @@
   X(KDEF_ZOOM, "Def_zoom", UINT)         \
   X(KGPS_TX, "GPS_tx", UINT)             \
   X(KGPS_RX, "GPS_rx", UINT)             \
-  X(KLAT_DFL, "defLAT", FLOAT)          \
-  X(KLON_DFL, "defLON", FLOAT)          \
+  X(KLAT_DFL, "defLAT", DOUBLE)          \
+  X(KLON_DFL, "defLON", DOUBLE)          \
   X(KCOUNT, "KCOUNT", UNKNOWN)

--- a/lib/preferences/preferences-keys.h
+++ b/lib/preferences/preferences-keys.h
@@ -18,8 +18,11 @@
   X(KCOMP_ROT, "Compass_rot", BOOL)      \
   X(KGPS_SPEED, "GPS_speed", SHORT)      \
   X(KGPS_RATE, "GPS_rate", SHORT)        \
+  X(KWEB_FILE, "Web_file", BOOL)         \
+  X(KUSER, "-----", UNKNOWN)             \
   X(KDEF_ZOOM, "Def_zoom", UINT)         \
   X(KGPS_TX, "GPS_tx", UINT)             \
   X(KGPS_RX, "GPS_rx", UINT)             \
-  X(KWEB_FILE, "Web_file", BOOL)         \
+  X(KLAT_DFL, "defLAT", FLOAT)          \
+  X(KLON_DFL, "defLON", FLOAT)          \
   X(KCOUNT, "KCOUNT", UNKNOWN)

--- a/lib/settings/settings.cpp
+++ b/lib/settings/settings.cpp
@@ -308,6 +308,7 @@ void printSettings()
   log_v("%11s \t%s \t%s", "=======", "=======", "=====");
 
   for (int i = 0; i < KCOUNT; i++) {
+    if (i == PKEYS::KUSER) continue;
     String key = cfg.getKey((CONFKEYS)i);
     bool isDefined = cfg.isKey(key);
     String defined = isDefined ? "custom " : "default";

--- a/platformio.ini
+++ b/platformio.ini
@@ -33,7 +33,7 @@ build_flags =
   -D SHELLMINATOR_BUFF_DIM=70
   -D SHELLMINATOR_LOGO_COLOR=BLUE
   -D COMMANDER_MAX_COMMAND_SIZE=70
-  -D WCLI_MAX_CMDS=10           # set n+1 of defined commands for CLI
+  -D WCLI_MAX_CMDS=12           # set n+1 of defined commands for CLI
   ; -D DISABLE_CLI_TELNET=1     # disable remote access via telnet. It needs CLI
   ; -D DISABLE_CLI=1            # removed CLI module. Config via Bluetooth only
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,11 +134,7 @@ void setup()
   splashScreen();
   initGpsTask();
 
-  #ifdef DEFAULT_LAT
-    loadMainScreen();
-  #else
-    lv_screen_load(searchSatScreen);
-  #endif
+  lv_screen_load(searchSatScreen);
 
   #ifndef DISABLE_CLI
     initCLI();


### PR DESCRIPTION
## Description

Now is possible define some settings only for the user via CLI, writing them on the preferences manifest, like this:

```cpp
#define CONFIG_KEYS_LIST                 \
  X(KMAP_ROT, "Map_rot", BOOL)           \
  X(KMAP_SPEED, "Map_speed", BOOL)       \
  X(KMAP_SCALE, "Map_scale", BOOL)       \
  X(KMAP_COMPASS, "Map_compass", BOOL)   \
  X(KMAP_VECTOR, "Map_vector", BOOL)     \
  X(KMAP_MODE, "Map_mode", BOOL)         \
...
  X(KCOMP_X, "Compass_X", INT)           \
  X(KGPS_RATE, "GPS_rate", SHORT)        \
  X(KWEB_FILE, "Web_file", BOOL)         \
  X(KUSER, "-----", UNKNOWN)             \      <==== below start the user preferences for the CLI
  X(KDEF_ZOOM, "Def_zoom", UINT)         \
  X(KGPS_TX, "GPS_tx", UINT)             \
  X(KGPS_RX, "GPS_rx", UINT)             \
  X(KLAT_DFL, "defLAT", DOUBLE)          \
  X(KLON_DFL, "defLON", DOUBLE)          \
  X(KCOUNT, "KCOUNT", UNKNOWN)
```

And the result is something like that:

![screenshot20241005_004524](https://github.com/user-attachments/assets/305b4c33-a4ba-4c49-beb7-cc0b403b9be1)

then now we have two commands:

```bash
klist:          list of user extra preferences
kset:          set an user extra preference
```

## Changes

33ff434 changed to verbose the lat/lon logs
08190d5 now lat/lon is checked from three sources, gps, settings and env
e767db7 two new CLI commands for set preferences. kset and klist
bd1bb6a added WCLI library with power issue fixed

