### PR TITLE
Add GPIO0 button to LVGL

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,11 @@ To do this, simply include the following Build Flag in the required env in platf
 | ILI9488     | 320x480    | --- | ---  | yes   | FT5x06    | ```-DILI9488_FT5x06_16B```       |
 | ILI9341     | 320x240    | yes | ---  | ---   | XPT2046   | ```-DILI9341_XPT2046_SPI```      |
 
-If TFT shares SPI bus with SD card add the following Build Flag to platformio.ini
+If TFT shares SPI bus with SD card add the followings Build Flag to platformio.ini
 
 ```-DSPI_SHARED```
+```-DARDUINO_RUNNING_CORE=1```
+```-DARDUINO_EVENT_RUNNING_CORE=1```
 
 ### Modules
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ To access the Web File Server, simply use any browser and go to the following ad
 - [X] LVGL Optimization 
 - [ ] GPX Integration
 - [ ] Multiple IMU's and Compass module implementation
-- [ ] Power saving
+- [X] Power saving
 - [X] Vector maps
 - [ ] Google Maps navigation style
 - [x] Optimize code

--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ Currently, IceNav works with the following hardware setups and specs
 | [MAKERFABS ESP32S3](https://www.makerfabs.com/esp32-s3-parallel-tft-with-touch-ili9488.html) |  16M  |  2M   | ``` [env:MAKERF_ESP32S3] ``` |   TESTING    |
 | [LILYGO T-DECK](https://www.lilygo.cc/products/t-deck) |  16M  |  8M   | ``` [env:TDECK_ESP32S3] ``` |   TESTING    |
 
+If the board has a BOOT button (GPIO0) it is possible to use power saving functions.
+To do this, simply include the following Build Flag in the required env in platformio.ini
+
+```-DPOWER_SAVE```
 
 > [!IMPORTANT]
 > Currently, this project can run on any board with an ESP32S3 and at least a 320x480 TFT screen. The idea is to support all existing boards on the market that I can get to work, so if you don't want to use the specific IceNav board, please feel free to create an issue, and I will look into providing support.

--- a/boards/elecrow-esp32-s3-n16r8v-terminal.json
+++ b/boards/elecrow-esp32-s3-n16r8v-terminal.json
@@ -8,7 +8,9 @@
       "core": "esp32",
       "extra_flags": [
         "-DBOARD_HAS_PSRAM",
-        "-DARDUINO_USB_MODE=1"
+        "-DARDUINO_USB_MODE=1",
+        "-DARDUINO_RUNNING_CORE=1",
+        "-DARDUINO_EVENT_RUNNING_CORE=1"
       ],
       "f_cpu": "240000000L",
       "f_flash": "80000000L",

--- a/boards/icenav-esp32-s3.json
+++ b/boards/icenav-esp32-s3.json
@@ -11,6 +11,8 @@
         "-DBOARD_HAS_PSRAM",
         "-DARDUINO_USB_MODE=1",
         "-DARDUINO_USB_CDC_ON_BOOT=1",
+        "-DARDUINO_RUNNING_CORE=1",
+        "-DARDUINO_EVENT_RUNNING_CORE=1",
         "-DPOWER_SAVE",
         "-DILI9488_FT5x06_SPI",
         "-DTFT_BL=45",

--- a/boards/icenav-esp32-s3.json
+++ b/boards/icenav-esp32-s3.json
@@ -11,6 +11,7 @@
         "-DBOARD_HAS_PSRAM",
         "-DARDUINO_USB_MODE=1",
         "-DARDUINO_USB_CDC_ON_BOOT=1",
+        "-DPOWER_SAVE",
         "-DILI9488_FT5x06_SPI",
         "-DTFT_BL=45",
         "-DSPI_SHARED",

--- a/include/hal.hpp
+++ b/include/hal.hpp
@@ -20,6 +20,8 @@
   uint8_t GPS_TX = 17;
   uint8_t GPS_RX = 18;
 
+  extern const uint8_t BOARD_BOOT_PIN = 0;
+
   extern const uint8_t TFT_SPI_SCLK = 12;
   extern const uint8_t TFT_SPI_MOSI = 11;
   extern const uint8_t TFT_SPI_MISO = 13;
@@ -56,6 +58,8 @@
   // Alternative to UART PORT
   uint8_t GPS_TX = 40;  // Analog PIN Terminal Port
   uint8_t GPS_RX = 19;  // Digital PIN Terminal Port
+
+  extern const uint8_t BOARD_BOOT_PIN = 0;
 
   extern const uint8_t SD_CS = 1;
   extern const uint8_t SD_MISO = 41;
@@ -104,6 +108,8 @@
   uint8_t GPS_TX = 17;
   uint8_t GPS_RX = 18;
 
+  extern const uint8_t BOARD_BOOT_PIN = 0;
+
   extern const uint8_t SD_CS = 1;
   extern const uint8_t SD_MISO = 41;
   extern const uint8_t SD_MOSI = 2;
@@ -146,6 +152,8 @@
   uint8_t GPS_TX = 25;
   uint8_t GPS_RX = 26;
 
+  extern const uint8_t BOARD_BOOT_PIN = 0;
+
   extern const uint8_t TFT_SPI_SCLK = 14;
   extern const uint8_t TFT_SPI_MOSI = 13;
   extern const uint8_t TFT_SPI_MISO = 27;
@@ -180,6 +188,8 @@
 
   uint8_t GPS_TX = 17;
   uint8_t GPS_RX = 18;
+
+  extern const uint8_t BOARD_BOOT_PIN = 0;
 
   extern const uint8_t TFT_SPI_SCLK = 12;
   extern const uint8_t TFT_SPI_MOSI = 11;

--- a/lib/gui/src/globalGuiDef.h
+++ b/lib/gui/src/globalGuiDef.h
@@ -32,6 +32,7 @@ extern lv_obj_t *waypointScreen;       // Add Waypoint Screen
 extern lv_obj_t *listWaypointScreen;   // List Waypoint Screen
 
 extern lv_group_t * scrGroup;          // Screen group
+extern lv_group_t * keyGroup;          // GPIO group
 
 extern bool needReboot;                // Flag to force device reboot
 extern bool isSearchingSat;            // Flag to indicate that is searching satellites

--- a/lib/gui/src/globalGuiDef.h
+++ b/lib/gui/src/globalGuiDef.h
@@ -41,6 +41,8 @@ extern lv_obj_t *menuBtn;              // Button Menu
 extern lv_obj_t *waypointName;         // Add / Edit Waypoint screen text area
 extern bool isScreenRotated;           // Flag to know if screen is rotated
 
+extern lv_obj_t *powerMsg;             // Power Message
+
 #ifdef LARGE_SCREEN
   static const lv_font_t *fontDefault = &lv_font_montserrat_14;
   static const lv_font_t *fontSmall = &lv_font_montserrat_10;

--- a/lib/gui/src/waypointScr.cpp
+++ b/lib/gui/src/waypointScr.cpp
@@ -200,7 +200,6 @@ void createWaypointScreen()
   #endif
 
   #ifdef TDECK_ESP32S3
-
     lv_group_add_obj(scrGroup, waypointName);
     lv_group_focus_obj(waypointName);
     //lv_group_add_obj(scrGroup, waypointScreen);

--- a/lib/lvgl/src/lvglSetup.cpp
+++ b/lib/lvgl/src/lvglSetup.cpp
@@ -150,6 +150,7 @@ void gpioLongEvent(lv_event_t *event)
   lv_event_code_t code = lv_event_get_code(event);
 
   log_v("GPIO Long pressed");
+  deviceShutdown();
 }
 
 /**
@@ -161,6 +162,7 @@ void gpioClickEvent(lv_event_t *event)
   lv_event_code_t code = lv_event_get_code(event);
 
   log_v("GPIO Single Clicked");
+  deviceSuspend();
 }
 
 /**

--- a/lib/lvgl/src/lvglSetup.cpp
+++ b/lib/lvgl/src/lvglSetup.cpp
@@ -120,6 +120,7 @@ void IRAM_ATTR keypadRead(lv_indev_t *indev_driver, lv_indev_data_t *data)
 #ifdef POWER_SAVE
 
 extern const uint8_t BOARD_BOOT_PIN;
+uint32_t deviceSuspendCount = 0;
 
 /**
 * @brief LVGL GPIO read
@@ -150,7 +151,8 @@ void gpioLongEvent(lv_event_t *event)
   lv_event_code_t code = lv_event_get_code(event);
 
   log_v("GPIO Long pressed");
-  deviceShutdown();
+  deviceSuspendCount = 1000;
+  //deviceShutdown();
 }
 
 /**
@@ -162,7 +164,8 @@ void gpioClickEvent(lv_event_t *event)
   lv_event_code_t code = lv_event_get_code(event);
 
   log_v("GPIO Single Clicked");
-  deviceSuspend();
+  deviceSuspendCount = 300;
+  //deviceSuspend();
 }
 
 /**

--- a/lib/lvgl/src/lvglSetup.cpp
+++ b/lib/lvgl/src/lvglSetup.cpp
@@ -24,6 +24,7 @@ lv_style_t styleObjectSel; // New Objects Selected Color
 
 lv_group_t *scrGroup;     // Screen group
 lv_group_t *keyGroup;     // GPIO group
+lv_obj_t *powerMsg;       // Power Message
 
 /**
  * @brief LVGL display update
@@ -150,7 +151,14 @@ void gpioLongEvent(lv_event_t *event)
 {
   lv_event_code_t code = lv_event_get_code(event);
   log_v("Shuting down device");
-  deviceSuspendCount = 1000;
+  powerMsg = lv_msgbox_create(lv_scr_act());
+  lv_obj_set_width(powerMsg,TFT_WIDTH - 20);
+  lv_obj_set_align(powerMsg,LV_ALIGN_CENTER);
+  lv_obj_set_style_text_font(powerMsg, fontDefault, 0);
+  lv_obj_t *labelText = lv_msgbox_get_content(powerMsg);
+  lv_obj_set_style_text_align(labelText, LV_TEXT_ALIGN_CENTER, 0);
+  lv_msgbox_add_text(powerMsg, LV_SYMBOL_WARNING " This device will shutdown shortly");
+  deviceSuspendCount = 800;
 }
 
 /**
@@ -163,6 +171,13 @@ void gpioClickEvent(lv_event_t *event)
   lv_indev_reset_long_press(lv_indev_active());
   lv_indev_reset(NULL,lv_scr_act());
   log_v("Entering sleep mode");
+  powerMsg = lv_msgbox_create(lv_scr_act());
+  lv_obj_set_width(powerMsg,TFT_WIDTH - 20);
+  lv_obj_set_align(powerMsg,LV_ALIGN_CENTER);
+  lv_obj_set_style_text_font(powerMsg, fontDefault, 0);
+  lv_obj_t *labelText = lv_msgbox_get_content(powerMsg);
+  lv_obj_set_style_text_align(labelText, LV_TEXT_ALIGN_CENTER, 0);
+  lv_msgbox_add_text(powerMsg, LV_SYMBOL_WARNING " This device will sleep shortly");
   deviceSuspendCount = 300;
 }
 

--- a/lib/lvgl/src/lvglSetup.cpp
+++ b/lib/lvgl/src/lvglSetup.cpp
@@ -149,10 +149,8 @@ void IRAM_ATTR gpioRead(lv_indev_t *indev_driver, lv_indev_data_t *data)
 void gpioLongEvent(lv_event_t *event)
 {
   lv_event_code_t code = lv_event_get_code(event);
-
-  log_v("GPIO Long pressed");
+  log_v("Shuting down device");
   deviceSuspendCount = 1000;
-  //deviceShutdown();
 }
 
 /**
@@ -162,10 +160,10 @@ void gpioLongEvent(lv_event_t *event)
 void gpioClickEvent(lv_event_t *event)
 {
   lv_event_code_t code = lv_event_get_code(event);
-
-  log_v("GPIO Single Clicked");
+  lv_indev_reset_long_press(lv_indev_active());
+  lv_indev_reset(NULL,lv_scr_act());
+  log_v("Entering sleep mode");
   deviceSuspendCount = 300;
-  //deviceSuspend();
 }
 
 /**

--- a/lib/lvgl/src/lvglSetup.hpp
+++ b/lib/lvgl/src/lvglSetup.hpp
@@ -46,7 +46,10 @@ void IRAM_ATTR touchRead(lv_indev_t *indev_driver, lv_indev_data_t *data);
     uint32_t keypadGetKey();
 #endif
 #ifdef POWER_SAVE
+    static const uint16_t longPressTime = 1000; // Long press time 
     void IRAM_ATTR gpioRead(lv_indev_t *indev_driver, lv_indev_data_t *data);
+    void gpioLongEvent(lv_event_t *event);
+    void gpioClickEvent(lv_event_t *event);
     uint8_t gpioGetBut();
 #endif
 void applyModifyTheme(lv_theme_t *th, lv_obj_t *obj);

--- a/lib/lvgl/src/lvglSetup.hpp
+++ b/lib/lvgl/src/lvglSetup.hpp
@@ -36,7 +36,6 @@
  * @brief Default display driver definition
  *
  */
-//extern lv_display_t *display;
 static uint32_t objectColor = 0x303030; 
 
 void IRAM_ATTR displayFlush(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map);

--- a/lib/lvgl/src/lvglSetup.hpp
+++ b/lib/lvgl/src/lvglSetup.hpp
@@ -45,6 +45,10 @@ void IRAM_ATTR touchRead(lv_indev_t *indev_driver, lv_indev_data_t *data);
     void IRAM_ATTR keypadRead(lv_indev_t *indev_driver, lv_indev_data_t *data);
     uint32_t keypadGetKey();
 #endif
+#ifdef POWER_SAVE
+    void IRAM_ATTR gpioRead(lv_indev_t *indev_driver, lv_indev_data_t *data);
+    uint8_t gpioGetBut();
+#endif
 void applyModifyTheme(lv_theme_t *th, lv_obj_t *obj);
 void modifyTheme();
 void lv_tick_task(void *arg);

--- a/lib/panel/ILI9341_XPT2046_SPI.hpp
+++ b/lib/panel/ILI9341_XPT2046_SPI.hpp
@@ -32,6 +32,7 @@ class LGFX : public lgfx::LGFX_Device
 {
   lgfx::Panel_ILI9341 _panel_instance;
   lgfx::Bus_SPI _bus_instance;
+  lgfx::Light_PWM _light_instance;
   lgfx::Touch_XPT2046 _touch_instance;
 
 public:
@@ -86,6 +87,17 @@ public:
       _panel_instance.config(cfg);
     }
 
+    {
+      auto cfg = _light_instance.config();
+      cfg.pin_bl = TFT_BL;
+      cfg.invert = false;
+      cfg.freq = 44100;
+      cfg.pwm_channel = 7;
+
+      _light_instance.config(cfg);
+      _panel_instance.setLight(&_light_instance);
+    }
+    
     {
       auto cfg = _touch_instance.config();
       cfg.x_min = 0;

--- a/lib/panel/ILI9488_FT5x06_16B.hpp
+++ b/lib/panel/ILI9488_FT5x06_16B.hpp
@@ -44,6 +44,7 @@ class LGFX : public lgfx::LGFX_Device
 {
   lgfx::Panel_ILI9488 _panel_instance;
   lgfx::Bus_Parallel16 _bus_instance;
+  lgfx::Light_PWM _light_instance;
   lgfx::Touch_FT5x06 _touch_instance;
 
 public:
@@ -104,7 +105,16 @@ public:
       _panel_instance.config(cfg);
     }
 
-    setPanel(&_panel_instance); 
+    {
+      auto cfg = _light_instance.config();
+      cfg.pin_bl = TFT_BL;
+      cfg.invert = false;
+      cfg.freq = 44100;
+      cfg.pwm_channel = 7;
+
+      _light_instance.config(cfg);
+      _panel_instance.setLight(&_light_instance);
+    }
 
     {
       auto cfg = _touch_instance.config();

--- a/lib/panel/ILI9488_FT5x06_SPI.hpp
+++ b/lib/panel/ILI9488_FT5x06_SPI.hpp
@@ -32,6 +32,7 @@ class LGFX : public lgfx::LGFX_Device
 {
   lgfx::Panel_ILI9488 _panel_instance;
   lgfx::Bus_SPI _bus_instance;
+  lgfx::Light_PWM _light_instance;
   lgfx::Touch_FT5x06 _touch_instance;
 
 public:
@@ -87,6 +88,17 @@ public:
       cfg.bus_shared = false;
       #endif
       _panel_instance.config(cfg);
+    }
+
+    {
+      auto cfg = _light_instance.config();
+      cfg.pin_bl = TFT_BL;
+      cfg.invert = false;
+      cfg.freq = 44100;
+      cfg.pwm_channel = 7;
+
+      _light_instance.config(cfg);
+      _panel_instance.setLight(&_light_instance);
     }
 
     {

--- a/lib/panel/ILI9488_NOTOUCH_8B.hpp
+++ b/lib/panel/ILI9488_NOTOUCH_8B.hpp
@@ -33,6 +33,7 @@ extern const uint8_t TFT_D7;
 class LGFX : public lgfx::LGFX_Device
 {
   lgfx::Panel_ILI9488 _panel_instance;
+  lgfx::Light_PWM _light_instance;
   lgfx::Bus_Parallel8 _bus_instance;
 
 public:
@@ -60,6 +61,17 @@ public:
       _panel_instance.setBus(&_bus_instance); 
     }
 
+    {
+      auto cfg = _light_instance.config();
+      cfg.pin_bl = TFT_BL;
+      cfg.invert = false;
+      cfg.freq = 44100;
+      cfg.pwm_channel = 7;
+
+      _light_instance.config(cfg);
+      _panel_instance.setLight(&_light_instance);
+    }
+    
     {                                        
       auto cfg = _panel_instance.config();
 

--- a/lib/panel/ILI9488_XPT2046_SPI.hpp
+++ b/lib/panel/ILI9488_XPT2046_SPI.hpp
@@ -33,6 +33,7 @@ class LGFX : public lgfx::LGFX_Device
 {
   lgfx::Panel_ILI9488 _panel_instance;
   lgfx::Bus_SPI _bus_instance;
+  lgfx::Light_PWM _light_instance;
   lgfx::Touch_XPT2046 _touch_instance;
 
 public:
@@ -85,6 +86,17 @@ public:
       cfg.bus_shared = false;
       #endif
       _panel_instance.config(cfg);
+    }
+
+    {
+      auto cfg = _light_instance.config();
+      cfg.pin_bl = TFT_BL;
+      cfg.invert = false;
+      cfg.freq = 44100;
+      cfg.pwm_channel = 7;
+
+      _light_instance.config(cfg);
+      _panel_instance.setLight(&_light_instance);
     }
 
     {

--- a/lib/power/power.cpp
+++ b/lib/power/power.cpp
@@ -83,7 +83,10 @@ void deviceSuspend()
   powerLightSleep();
   tft.setBrightness(brightness);
   //tftOn();
-  while (digitalRead(BOARD_BOOT_PIN) != 1);
+  while (digitalRead(BOARD_BOOT_PIN) != 1)
+  { 
+    delay(5);
+  };
   log_v("Exited sleep mode");
 }
 

--- a/lib/power/power.cpp
+++ b/lib/power/power.cpp
@@ -16,14 +16,14 @@
  * @brief Deep Sleep Mode
  * 
  */
-void powerDeepSeep()
+void powerDeepSleep()
 {
   esp_bluedroid_disable();
   esp_bt_controller_disable();
   esp_wifi_stop();
   esp_deep_sleep_disable_rom_logging();
   delay(10);
-#ifdef TDECK_ESP32S3
+#ifdef POWER_SAVE
   // If you need other peripherals to maintain power, please set the IO port to hold
   // gpio_hold_en((gpio_num_t)BOARD_POWERON);
   // gpio_deep_sleep_hold_en();
@@ -50,7 +50,7 @@ void powerLightSleepTimer(int millis)
  */
 void powerLightSleep()
 {
-#ifdef TDECK_ESP32S3
+#ifdef POWER_SAVE
   esp_sleep_enable_ext1_wakeup(1ull << BOARD_BOOT_PIN, ESP_EXT1_WAKEUP_ANY_LOW);
 #endif
   esp_light_sleep_start();
@@ -84,12 +84,12 @@ void deviceSuspend()
 }
 
 /**
- * @brief Power off peripherals and deepsleep
+ * @brief Power off peripherals and deep sleep
  */
 void deviceShutdown()
 {
   powerOffPeripherals();
-  powerDeepSeep();
+  powerDeepSleep();
 }
 
 /**

--- a/lib/power/power.cpp
+++ b/lib/power/power.cpp
@@ -58,7 +58,7 @@ void powerLightSleep()
 
 void powerOffScreen()
 {
-#ifdef TDECK_ESP32S3
+// #ifdef TDECK_ESP32S3
   // LilyGo T-Deck control backlight chip has 16 levels of adjustment range
   // for (int i = 16; i > 0; --i) {
   //   setBrightness(i);
@@ -67,9 +67,9 @@ void powerOffScreen()
   tft.setBrightness(0);
   // tft.getPanel()->setSleep(true);
   // TODO: we could need a complete panel power off?
-#else
-  setBrightness(0);
-#endif
+// #else
+//   setBrightness(0);
+// #endif
 }
 
 /**

--- a/lib/power/power.cpp
+++ b/lib/power/power.cpp
@@ -58,6 +58,7 @@ void deviceSuspend()
   int brightness = tft.getBrightness();
   tftOff();
   powerLightSleep();
+  lv_msgbox_close(powerMsg);  
   tftOn(brightness);
   while (digitalRead(BOARD_BOOT_PIN) != 1)
   { 

--- a/lib/power/power.cpp
+++ b/lib/power/power.cpp
@@ -8,7 +8,7 @@
 
 #include "power.hpp"
 
-#ifdef TDECK_ESP32S3
+#ifdef POWER_SAVE
   extern const uint8_t BOARD_BOOT_PIN;
 #endif
 

--- a/lib/power/power.cpp
+++ b/lib/power/power.cpp
@@ -79,8 +79,12 @@ void deviceSuspend()
 {
   int brightness = tft.getBrightness();
   powerOffScreen();
+  //tftOff();
   powerLightSleep();
   tft.setBrightness(brightness);
+  //tftOn();
+  while (digitalRead(BOARD_BOOT_PIN) != 1);
+  log_v("Exited sleep mode");
 }
 
 /**
@@ -100,6 +104,7 @@ void powerOffPeripherals()
   powerOffScreen();
   tft.getPanel()->setSleep(true); // sounds that it is not working
   tft.writecommand(0x10);  // set display enter sleep mode
+  //tftOff();
   SPI.end();
   Wire.end();
 }

--- a/lib/power/power.cpp
+++ b/lib/power/power.cpp
@@ -8,9 +8,7 @@
 
 #include "power.hpp"
 
-#ifdef POWER_SAVE
-  extern const uint8_t BOARD_BOOT_PIN;
-#endif
+extern const uint8_t BOARD_BOOT_PIN;
 
 /**
  * @brief Deep Sleep Mode
@@ -23,12 +21,10 @@ void powerDeepSleep()
   esp_wifi_stop();
   esp_deep_sleep_disable_rom_logging();
   delay(10);
-#ifdef POWER_SAVE
   // If you need other peripherals to maintain power, please set the IO port to hold
   // gpio_hold_en((gpio_num_t)BOARD_POWERON);
   // gpio_deep_sleep_hold_en();
   esp_sleep_enable_ext1_wakeup(1ull << BOARD_BOOT_PIN, ESP_EXT1_WAKEUP_ANY_LOW);
-#endif
   esp_deep_sleep_start();
 }
 
@@ -50,26 +46,8 @@ void powerLightSleepTimer(int millis)
  */
 void powerLightSleep()
 {
-#ifdef POWER_SAVE
   esp_sleep_enable_ext1_wakeup(1ull << BOARD_BOOT_PIN, ESP_EXT1_WAKEUP_ANY_LOW);
-#endif
   esp_light_sleep_start();
-}
-
-void powerOffScreen()
-{
-// #ifdef TDECK_ESP32S3
-  // LilyGo T-Deck control backlight chip has 16 levels of adjustment range
-  // for (int i = 16; i > 0; --i) {
-  //   setBrightness(i);
-  //   delay(30);
-  // }
-  tft.setBrightness(0);
-  // tft.getPanel()->setSleep(true);
-  // TODO: we could need a complete panel power off?
-// #else
-//   setBrightness(0);
-// #endif
 }
 
 /**
@@ -78,11 +56,9 @@ void powerOffScreen()
 void deviceSuspend()
 {
   int brightness = tft.getBrightness();
-  powerOffScreen();
-  //tftOff();
+  tftOff();
   powerLightSleep();
-  tft.setBrightness(brightness);
-  //tftOn();
+  tftOn(brightness);
   while (digitalRead(BOARD_BOOT_PIN) != 1)
   { 
     delay(5);
@@ -104,11 +80,10 @@ void deviceShutdown()
  */
 void powerOffPeripherals()
 {
-  powerOffScreen();
-  tft.getPanel()->setSleep(true); // sounds that it is not working
-  tft.writecommand(0x10);  // set display enter sleep mode
-  //tftOff();
-  SPI.end();
+  tftOff();
+  #ifdef TDECK_ESP32S3
+    SPI.end();
+  #endif
   Wire.end();
 }
 

--- a/lib/power/power.hpp
+++ b/lib/power/power.hpp
@@ -22,7 +22,6 @@ void powerDeepSeep();
 void powerLightSleepTimer(int millis);
 void powerLightSleep();
 void powerOffPeripherals();
-void powerOffScreen();
 void deviceSuspend();
 void deviceShutdown();
 void powerOn();

--- a/lib/power/power.hpp
+++ b/lib/power/power.hpp
@@ -17,6 +17,7 @@
 #include <esp_wifi.h>
 #include "tft.hpp"
 #include "lvgl.h"
+#include "globalGuiDef.h"
 
 void powerDeepSeep();
 void powerLightSleepTimer(int millis);

--- a/lib/power/power.hpp
+++ b/lib/power/power.hpp
@@ -16,6 +16,7 @@
 #include <esp_bt_main.h>
 #include <esp_wifi.h>
 #include "tft.hpp"
+#include "lvgl.h"
 
 void powerDeepSeep();
 void powerLightSleepTimer(int millis);

--- a/lib/tft/tft.cpp
+++ b/lib/tft/tft.cpp
@@ -77,10 +77,11 @@ uint8_t getBrightness()
  * @brief Turn on TFT Sleep Mode for ILI9488
  *
  */
-void tftOn()
+void tftOn(uint8_t brightness)
 {
   tft.writecommand(0x11);
-  setBrightness(255);
+  delay(120);
+  tft.setBrightness(brightness);
 }
 
 /**
@@ -89,8 +90,8 @@ void tftOn()
  */
 void tftOff()
 {
+  tft.setBrightness(0);
   tft.writecommand(0x10);
-  setBrightness(0);
 }
 
 /**
@@ -164,7 +165,7 @@ void touchCalibrate()
 void initTFT()
 {
   tft.init();
-
+  
   #ifdef TDECK_ESP32S3
     tft.setRotation(1);
   #endif

--- a/lib/tft/tft.hpp
+++ b/lib/tft/tft.hpp
@@ -56,7 +56,7 @@ extern bool waitScreenRefresh;                  // Wait for refresh screen (scre
 
 void setBrightness(uint8_t brightness);
 uint8_t getBrightness();
-void tftOn();
+void tftOn(uint8_t brightness);
 void tftOff();
 void touchCalibrate();
 void initTFT();

--- a/platformio.ini
+++ b/platformio.ini
@@ -137,6 +137,7 @@ lib_deps =
 build_flags =
   ${common.build_flags}
   -DILI9488_FT5x06_16B
+  -DPOWER_SAVE
   -DAT6558D_GPS
   -DHMC5883L
 ; -DBME280

--- a/platformio.ini
+++ b/platformio.ini
@@ -64,6 +64,8 @@ lib_deps =
   dfrobot/DFRobot_QMC5883@^1.0.0
 build_flags =
   ${common.build_flags}
+  -DARDUINO_RUNNING_CORE=1
+  -DARDUINO_EVENT_RUNNING_CORE=1
 
 [env:MAKERF_ESP32S3]
 extends = esp32_common

--- a/platformio.ini
+++ b/platformio.ini
@@ -46,7 +46,7 @@ lib_deps =
 	bblanchon/StreamUtils@^1.9.0
   hpsaturn/EasyPreferences@^0.1.2
   hpsaturn/ESP32 Wifi CLI@^0.3.1
-  vortigont/ESPAsyncButton@^1.2.1
+  ; vortigont/ESPAsyncButton@^1.2.1
   kubafilinger/AsyncTCP@^1.1.1
   esphome/ESPAsyncWebServer-esphome@^2.1.0
 
@@ -149,6 +149,7 @@ upload_speed = 921600
 build_flags = 
   ${common.build_flags}
   -DBOARD_HAS_PSRAM
+  -DPOWER_SAVE
   -DSPI_SHARED
   -DAT6558D_GPS
   -DARDUINO_USB_CDC_ON_BOOT=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -46,7 +46,6 @@ lib_deps =
 	bblanchon/StreamUtils@^1.9.0
   hpsaturn/EasyPreferences@^0.1.2
   hpsaturn/ESP32 Wifi CLI@^0.3.1
-  ; vortigont/ESPAsyncButton@^1.2.1
   kubafilinger/AsyncTCP@^1.1.1
   esphome/ESPAsyncWebServer-esphome@^2.1.0
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -64,8 +64,6 @@ lib_deps =
   dfrobot/DFRobot_QMC5883@^1.0.0
 build_flags =
   ${common.build_flags}
-  -DARDUINO_RUNNING_CORE=1
-  -DARDUINO_EVENT_RUNNING_CORE=1
 
 [env:MAKERF_ESP32S3]
 extends = esp32_common

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,7 @@ extern xSemaphoreHandle gpsMutex;
 
 // AsyncEventButton b1(GPIO_NUM_0, LOW);
 
-// uint32_t deviceSuspendCount = 0;
+extern uint32_t deviceSuspendCount;
 
 // void on_multi_click(int32_t counter){
 //   Serial.println("device suspend..");
@@ -75,7 +75,7 @@ void setup()
   
   // Force GPIO0 to internal PullUP  during boot (avoid LVGL key read)
   #ifdef POWER_SAVE
-    pinMode(BOARD_BOOT_PIN,INPUT_PULLUP);
+     pinMode(BOARD_BOOT_PIN,INPUT_PULLUP);
   #endif
 
   #ifdef ARDUINO_USB_CDC_ON_BOOT
@@ -190,7 +190,7 @@ void loop()
     lv_timer_handler();
     vTaskDelay(pdMS_TO_TICKS(TASK_SLEEP_PERIOD_MS));
   }
-  // if (deviceSuspendCount == 500) deviceShutdown();
-  // if (deviceSuspendCount == 1) deviceSuspend();
-  // if (deviceSuspendCount > 0 ) deviceSuspendCount--;
+  if (deviceSuspendCount == 500) deviceShutdown();
+  if (deviceSuspendCount == 1) deviceSuspend();
+  if (deviceSuspendCount > 0 ) deviceSuspendCount--;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,6 @@
 #include <AsyncTCP.h>
 #include <ESPAsyncWebServer.h>
 #include <Timezone.h>
-// #include <espasyncbutton.hpp>
 
 // Hardware includes
 #include "hal.hpp"
@@ -51,19 +50,7 @@ extern xSemaphoreHandle gpsMutex;
 #include "lvglSetup.hpp"
 #include "tasks.hpp"
 
-// AsyncEventButton b1(GPIO_NUM_0, LOW);
-
 extern uint32_t deviceSuspendCount;
-
-// void on_multi_click(int32_t counter){
-//   Serial.println("device suspend..");
-//   deviceSuspendCount = 300;
-// }
-
-// void on_long_press(){
-//   Serial.println("device shutdown..");
-//   deviceSuspendCount = 1000;
-// }
 
 /**
  * @brief Setup
@@ -172,11 +159,6 @@ void setup()
 
   if(WiFi.getMode() == WIFI_OFF)
     ESP_ERROR_CHECK(esp_event_loop_create_default());
-
-  // b1.begin();
-  // b1.onMultiClick(on_multi_click);
-  // b1.onLongPress(on_long_press);
-  // b1.enable();
 }
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@
 #include <AsyncTCP.h>
 #include <ESPAsyncWebServer.h>
 #include <Timezone.h>
-#include <espasyncbutton.hpp>
+// #include <espasyncbutton.hpp>
 
 // Hardware includes
 #include "hal.hpp"
@@ -51,19 +51,19 @@ extern xSemaphoreHandle gpsMutex;
 #include "lvglSetup.hpp"
 #include "tasks.hpp"
 
-AsyncEventButton b1(GPIO_NUM_0, LOW);
+// AsyncEventButton b1(GPIO_NUM_0, LOW);
 
-uint32_t deviceSuspendCount = 0;
+// uint32_t deviceSuspendCount = 0;
 
-void on_multi_click(int32_t counter){
-  Serial.println("device suspend..");
-  deviceSuspendCount = 300;
-}
+// void on_multi_click(int32_t counter){
+//   Serial.println("device suspend..");
+//   deviceSuspendCount = 300;
+// }
 
-void on_long_press(){
-  Serial.println("device shutdown..");
-  deviceSuspendCount = 1000;
-}
+// void on_long_press(){
+//   Serial.println("device shutdown..");
+//   deviceSuspendCount = 1000;
+// }
 
 /**
  * @brief Setup
@@ -165,12 +165,12 @@ void setup()
     server.begin();
   }
 
-  if(WiFi.getMode() == WIFI_OFF)
-    ESP_ERROR_CHECK(esp_event_loop_create_default());
-  b1.begin();
-  b1.onMultiClick(on_multi_click);
-  b1.onLongPress(on_long_press);
-  b1.enable();
+  // if(WiFi.getMode() == WIFI_OFF)
+  //   ESP_ERROR_CHECK(esp_event_loop_create_default());
+  // b1.begin();
+  // b1.onMultiClick(on_multi_click);
+  // b1.onLongPress(on_long_press);
+  // b1.enable();
 }
 
 /**
@@ -184,7 +184,7 @@ void loop()
     lv_timer_handler();
     vTaskDelay(pdMS_TO_TICKS(TASK_SLEEP_PERIOD_MS));
   }
-  if (deviceSuspendCount == 500) deviceShutdown();
-  if (deviceSuspendCount == 1) deviceSuspend();
-  if (deviceSuspendCount > 0 ) deviceSuspendCount--;
+  // if (deviceSuspendCount == 500) deviceShutdown();
+  // if (deviceSuspendCount == 1) deviceSuspend();
+  // if (deviceSuspendCount > 0 ) deviceSuspendCount--;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,6 +72,11 @@ extern xSemaphoreHandle gpsMutex;
 void setup()
 {
   gpsMutex = xSemaphoreCreateMutex();
+  
+  // Force GPIO0 to internal PullUP  during boot (avoid LVGL key read)
+  #ifdef POWER_SAVE
+    pinMode(BOARD_BOOT_PIN,INPUT_PULLUP);
+  #endif
 
   #ifdef ARDUINO_USB_CDC_ON_BOOT
     Serial.begin(115200);  
@@ -165,8 +170,9 @@ void setup()
     server.begin();
   }
 
-  // if(WiFi.getMode() == WIFI_OFF)
-  //   ESP_ERROR_CHECK(esp_event_loop_create_default());
+  if(WiFi.getMode() == WIFI_OFF)
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+
   // b1.begin();
   // b1.onMultiClick(on_multi_click);
   // b1.onLongPress(on_long_press);


### PR DESCRIPTION
## Description
Add GPIO0 button to LVGL to be able to use the different power saving modes

Long Press -> Power off
Simple click -> Suspend

## issues

#216 

## Knew issues

- [x] Preload map doesn't works 
- [x] ICENAV Board or Elecrow board doesn't enter in sleep mode o deep sleep mode
- [x] Long press raised after simple click
- [x] Map not loaded when exits sleep mode

## Tests
- [x] Add GPIO reading in LVGL
- [x] Add LVGL Events for GPIO
- [x] Try different power saving modes
- [x] Simple click and long click in the map screen
- [x] Review TFT sleep mode
- [x] Tests in LilyGo T-DECK (Check with keyboard to avoid conflicts)
- [x] Map screen when exit sleep mode (SPI end¿?)

