### PR TITLE
Brightness persistence and some related refactors

### DIFF
--- a/lib/gui/src/deviceSettingsScr.cpp
+++ b/lib/gui/src/deviceSettingsScr.cpp
@@ -30,17 +30,20 @@ void deviceSettingsEvent(lv_event_t *event)
     gpsUpdate = lv_dropdown_get_selected(obj);
     saveGPSUpdateRate(gpsUpdate);
   }
-  if (strcmp(option,"back") == 0)
+  if (strcmp(option, "back") == 0)
+  {
+    log_i("saving brightness to: %i", defBright);
+    saveBrightness(defBright);
     lv_screen_load(settingsScreen);
+  }
 }
 
 void lv_brightness_cb(lv_event_t *e)
 {
     lv_obj_t *obj =(lv_obj_t*) lv_event_get_target(e);
-    uint8_t val =  lv_slider_get_value(obj);
-    log_i("brightness %i",val);
-    tft.setBrightness(val);
-    defBright = val;
+    defBright =  lv_slider_get_value(obj);
+    log_i("brightness %i", defBright);
+    tft.setBrightness(defBright);
 }
 
 // void lv_background_opa_cb(lv_event_t *e)

--- a/lib/gui/src/deviceSettingsScr.cpp
+++ b/lib/gui/src/deviceSettingsScr.cpp
@@ -150,7 +150,7 @@ void createDeviceSettingsScr()
   lv_obj_align_to(dropdown, list, LV_ALIGN_OUT_RIGHT_MID, 0, 0);
   lv_obj_add_event_cb(dropdown, deviceSettingsEvent, LV_EVENT_VALUE_CHANGED, (char*)"rate");
 
-  create_slider(deviceSettingsOptions, LV_SYMBOL_SETTINGS, "Brightness", 5, 254, 128, lv_brightness_cb, LV_EVENT_VALUE_CHANGED);
+  create_slider(deviceSettingsOptions, LV_SYMBOL_SETTINGS, "Brightness", 5, 255, 128, lv_brightness_cb, LV_EVENT_VALUE_CHANGED);
   // create_slider(deviceSettingsOptions, LV_SYMBOL_SETTINGS, "Background", 0, 255, 128, lv_background_opa_cb, LV_EVENT_VALUE_CHANGED);
 
   // Back button

--- a/lib/gui/src/deviceSettingsScr.cpp
+++ b/lib/gui/src/deviceSettingsScr.cpp
@@ -40,6 +40,7 @@ void lv_brightness_cb(lv_event_t *e)
     uint8_t val =  lv_slider_get_value(obj);
     log_i("brightness %i",val);
     tft.setBrightness(val);
+    defBright = val;
 }
 
 // void lv_background_opa_cb(lv_event_t *e)
@@ -150,7 +151,7 @@ void createDeviceSettingsScr()
   lv_obj_align_to(dropdown, list, LV_ALIGN_OUT_RIGHT_MID, 0, 0);
   lv_obj_add_event_cb(dropdown, deviceSettingsEvent, LV_EVENT_VALUE_CHANGED, (char*)"rate");
 
-  create_slider(deviceSettingsOptions, LV_SYMBOL_SETTINGS, "Brightness", 5, 255, 128, lv_brightness_cb, LV_EVENT_VALUE_CHANGED);
+  create_slider(deviceSettingsOptions, LV_SYMBOL_SETTINGS, "Brightness", 5, 255, defBright, lv_brightness_cb, LV_EVENT_VALUE_CHANGED);
   // create_slider(deviceSettingsOptions, LV_SYMBOL_SETTINGS, "Background", 0, 255, 128, lv_background_opa_cb, LV_EVENT_VALUE_CHANGED);
 
   // Back button

--- a/lib/gui/src/settingsScr.cpp
+++ b/lib/gui/src/settingsScr.cpp
@@ -22,9 +22,6 @@ static void back(lv_event_t *event)
     lv_screen_load(searchSatScreen);
   else
     loadMainScreen();
-
-  log_i("saving brightness to:\t%i",defBright);
-  saveBrightness(defBright);
 }
 
 /**

--- a/lib/gui/src/settingsScr.cpp
+++ b/lib/gui/src/settingsScr.cpp
@@ -22,6 +22,9 @@ static void back(lv_event_t *event)
     lv_screen_load(searchSatScreen);
   else
     loadMainScreen();
+
+  log_i("saving brightness to:\t%i",defBright);
+  saveBrightness(defBright);
 }
 
 /**

--- a/lib/gui/src/settingsScr.hpp
+++ b/lib/gui/src/settingsScr.hpp
@@ -13,6 +13,7 @@
 #include "mainScr.hpp"
 #include "compass.hpp"
 #include "searchSatScr.hpp"
+#include "settings.hpp"
 
 void loadMainScreen();
 

--- a/lib/gui/src/splashScr.cpp
+++ b/lib/gui/src/splashScr.cpp
@@ -54,7 +54,7 @@ void splashScreen()
   tft.setTextColor(TFT_WHITE, TFT_BLACK);
 
   // #ifndef TDECK_ESP32S3
-    const uint8_t maxBrightness = 255;
+  const uint8_t maxBrightness = 254;
   // #endif
   // #ifdef TDECK_ESP32S3
     // const uint8_t maxBrightness = 16;
@@ -79,6 +79,6 @@ void splashScreen()
   while (millis() < millisActual + 100)
     ;
 
-  tft.fillScreen(TFT_BLACK);
+  // tft.fillScreen(TFT_BLACK);
   tft.setBrightness(maxBrightness);
 }

--- a/lib/gui/src/splashScr.cpp
+++ b/lib/gui/src/splashScr.cpp
@@ -53,12 +53,7 @@ void splashScreen()
   memset(&statusString[0], 0, sizeof(statusString));
   tft.setTextColor(TFT_WHITE, TFT_BLACK);
 
-  // #ifndef TDECK_ESP32S3
-  const uint8_t maxBrightness = 254;
-  // #endif
-  // #ifdef TDECK_ESP32S3
-    // const uint8_t maxBrightness = 16;
-  // #endif
+  const uint8_t maxBrightness = 255;
 
   for (uint8_t fadeIn = 0; fadeIn <= ( maxBrightness - 1); fadeIn++)
   {
@@ -68,7 +63,7 @@ void splashScreen()
       ;
   }
 
-  for (uint8_t fadeOut = maxBrightness; fadeOut > 0; fadeOut--)
+  for (uint8_t fadeOut = maxBrightness; fadeOut > defBright; fadeOut--)
   {
     tft.setBrightness(fadeOut);
     millisActual = millis();
@@ -78,7 +73,4 @@ void splashScreen()
 
   while (millis() < millisActual + 100)
     ;
-
-  // tft.fillScreen(TFT_BLACK);
-  tft.setBrightness(maxBrightness);
 }

--- a/lib/gui/src/splashScr.hpp
+++ b/lib/gui/src/splashScr.hpp
@@ -11,6 +11,7 @@
 
 #include "tft.hpp"
 #include "globalGuiDef.h"
+#include "settings.hpp"
 
 #ifdef LARGE_SCREEN
 static const char* logoFile PROGMEM = "/spiffs/LOGO_LARGE.png";

--- a/lib/preferences/preferences-keys.h
+++ b/lib/preferences/preferences-keys.h
@@ -25,7 +25,7 @@
   X(KGPS_RX, "GPS_rx", UINT)             \
   X(KLAT_DFL, "defLAT", DOUBLE)          \
   X(KLON_DFL, "defLON", DOUBLE)          \
-  X(KBRIGT_DFL, "defBright", INT)        \
+  X(KDEF_BRIGT, "defBright", UINT)        \
   X(KVMAX_BATT, "VmaxBatt", FLOAT)       \
   X(KVMIN_BATT, "VminBatt", FLOAT)       \
   X(KCOUNT, "KCOUNT", UNKNOWN)

--- a/lib/settings/settings.cpp
+++ b/lib/settings/settings.cpp
@@ -30,6 +30,7 @@ uint8_t zoom = 0;           // Actual Zoom Level
  */
 bool isMapRotation = true;    // Map Compass Rotation
 uint8_t defaultZoom = 0;      // Default Zoom Value
+uint8_t defBright = 255;      // Default Brightness
 bool showMapCompass = true;   // Compass in map screen
 bool isCompassRot = true;     // Compass rotation in map screen
 bool showMapSpeed = true;     // Speed in map screen
@@ -78,6 +79,7 @@ void loadPreferences()
   speedPosX = cfg.getInt(PKEYS::KSPEED_X, 1);
   speedPosY = cfg.getInt(PKEYS::KSPEED_Y, TFT_HEIGHT - 130);
   isVectorMap = cfg.getBool(PKEYS::KMAP_VECTOR, false);
+  defBright = cfg.getUInt(PKEYS::KDEF_BRIGT, 254);
   if (isVectorMap)
   {
     minZoom = 1;
@@ -315,6 +317,16 @@ void saveGpsGpio(int8_t txGpio, int8_t rxGpio)
 void saveWebFile(bool status)
 {
   cfg.saveBool(PKEYS::KWEB_FILE, status);
+}
+
+/**
+ * @brief Save default Brightness
+ *
+ * @param status 
+ */
+void saveBrightness(uint8_t vb)
+{
+  cfg.saveUInt(PKEYS::KDEF_BRIGT, vb);
 }
 
 /**

--- a/lib/settings/settings.hpp
+++ b/lib/settings/settings.hpp
@@ -20,6 +20,7 @@ extern uint8_t maxZoom;        // Max Zoom Level
 extern uint8_t defZoomRender;  // Default Zoom Level for render map
 extern uint8_t defZoomVector;  // Default Zoom Level for vector map
 extern uint8_t zoom;           // Actual Zoom Level
+extern uint8_t defBright;      // Default brightness
 extern float batteryMax;       // 4.2;      // maximum voltage of battery
 extern float batteryMin;       // 3.6;      // minimum voltage of battery before shutdown
 
@@ -59,6 +60,7 @@ void saveMapType(bool vector);
 void saveShowMap(bool mapMode);
 void saveGpsGpio(int8_t txGpio, int8_t rxGpio);
 void saveWebFile(bool status);
+void saveBrightness(uint8_t vb);
 void printSettings();
 
 #endif

--- a/lib/tft/tft.cpp
+++ b/lib/tft/tft.cpp
@@ -18,60 +18,7 @@ bool waitScreenRefresh = false;
   extern const uint8_t TFT_SPI_BL;
 #endif
 
-/**
- * @brief Set the TFT brightness
- *
- * @param brightness -> 0..255 / 0..15 for T-DECK
- */
-void setBrightness(uint8_t brightness)
-{
-  
-  #ifndef TDECK_ESP32S3 
-  if (brightness <= 255)
-  {
-   ledcWrite(0, brightness);
-   brightnessLevel = brightness;
-  }
-  #endif
 
-  #ifdef TDECK_ESP32S3 
-    static uint8_t level = 0;
-    static uint8_t steps = 16;
-    if (brightness == 0) 
-    {
-      digitalWrite(TFT_SPI_BL, 0);
-      delay(3);
-      level = 0;
-      return;
-    }
-    if (level == 0) 
-    {
-      digitalWrite(TFT_SPI_BL, 1);
-      level = steps;
-      delayMicroseconds(30);
-    }
-    int from = steps - level;
-    int to = steps - brightness;
-    int num = (steps + to - from) % steps;
-    for (int i = 0; i < num; i++) 
-    {
-      digitalWrite(TFT_SPI_BL, 0);
-      digitalWrite(TFT_SPI_BL, 1);
-    }
-    level = brightness;
-    brightnessLevel = brightness;
-  #endif
-}
-
-/**
- * @brief Get the TFT brightness
- *
- * @return int -> brightness value 0..255 / 0..15 for T-DECK
- */
-uint8_t getBrightness()
-{
-  return brightnessLevel;
-}
 
 /**
  * @brief Turn on TFT Sleep Mode for ILI9488

--- a/lib/tft/tft.hpp
+++ b/lib/tft/tft.hpp
@@ -42,10 +42,6 @@ extern TFT_eSPI tft;
 static const char* calibrationFile PROGMEM = "/spiffs/TouchCal";
 extern bool repeatCalib;
 
-#ifndef TDECK_ESP32S3
-    static uint8_t brightnessLevel = 255;
-#endif
-
 extern uint16_t TFT_WIDTH;
 extern uint16_t TFT_HEIGHT;
 extern bool waitScreenRefresh;                  // Wait for refresh screen (screenshot issues)

--- a/lib/tft/tft.hpp
+++ b/lib/tft/tft.hpp
@@ -45,17 +45,11 @@ extern bool repeatCalib;
 #ifndef TDECK_ESP32S3
     static uint8_t brightnessLevel = 255;
 #endif
-#ifdef TDECK_ESP32S3
-    static uint8_t brightnessLevel = 15;
-#endif
 
 extern uint16_t TFT_WIDTH;
 extern uint16_t TFT_HEIGHT;
 extern bool waitScreenRefresh;                  // Wait for refresh screen (screenshot issues)
 
-
-void setBrightness(uint8_t brightness);
-uint8_t getBrightness();
 void tftOn(uint8_t brightness);
 void tftOff();
 void touchCalibrate();


### PR DESCRIPTION
## Description

This PR improve the brightness persistence and also removed some deprecated code. In addition, the boot animation follow the user brightness, that means that it first start with a fade in from 0 to max and it over with a fade out from max to the user brightness setting.

d879d60 now the brightness persist in flash. Improved fade animation
d5e2c46 removed deprecated method setBrightness and some minor refactors

## Related Issues

#228 

## Tests

- [x] T-Deck board
- [x] Custom board
- [x] Elecrow board