### PR TITLE
Add custom settings for temperature offset (+/-)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,30 @@ wipe:           wipe preferences to factory default
 
 Some extra details:
 
+**klist**: List user custom settings:
+
+```
+    KEYNAME     DEFINED         VALUE 
+    =======     =======         ===== 
+    defZoom     custom         
+      gpsTX     custom          
+      gpsRX     custom          
+     defLAT     custom          
+     defLON     custom           
+  defBright     custom          
+   VmaxBatt     custom         
+   VminBatt     custom          
+   tempOffs     custom
+```          
+
+**kset KEYNAME**: Set user custom settings:
+
+In order to simplify the configuration of the device (minimum and maximum battery level, default position, etc...) via CLI it is possible to specify default values ​​for the configuration.
+This has been done in order to speed up the device configuration process without having to invest "time" in modifying and creating extra configuration screens in the GUI (LVGL).
+
+Available user parameters can be obtained using the **klist** command with a CLI connection (either via USB connection or TELNET connection)
+
+
 **nmcli**: IceNav use a `wcli` network manager library. For more details of this command and its sub commands please refer to [here](https://github.com/hpsaturn/esp32-wifi-cli?tab=readme-ov-file#readme)
 
 **outnmea**: this command toggle the GPS output to the serial console. With that it will be compatible with external GPS software like `PyGPSClient` and others. To stop these messages in your console, just only repeat the same command or perform a `CTRL+C`.

--- a/lib/gui/src/notifyBar.cpp
+++ b/lib/gui/src/notifyBar.cpp
@@ -107,7 +107,6 @@ void updateNotifyBarTimer(lv_timer_t *t)
     lv_led_off(gpsFix);
 
   #ifdef ENABLE_TEMP
-  log_v("%d", tempOffset);
   tempValue = (uint8_t)(bme.readTemperature() + tempOffset);
   if (tempValue != tempOld)
   {

--- a/lib/gui/src/notifyBar.cpp
+++ b/lib/gui/src/notifyBar.cpp
@@ -107,7 +107,8 @@ void updateNotifyBarTimer(lv_timer_t *t)
     lv_led_off(gpsFix);
 
   #ifdef ENABLE_TEMP
-  tempValue = (uint8_t)(bme.readTemperature());
+  log_v("%d", tempOffset);
+  tempValue = (uint8_t)(bme.readTemperature() + tempOffset);
   if (tempValue != tempOld)
   {
     lv_obj_send_event(temp, LV_EVENT_VALUE_CHANGED, NULL);

--- a/lib/preferences/preferences-keys.h
+++ b/lib/preferences/preferences-keys.h
@@ -28,4 +28,5 @@
   X(KDEF_BRIGT, "defBright", UINT)       \
   X(KVMAX_BATT, "VmaxBatt", FLOAT)       \
   X(KVMIN_BATT, "VminBatt", FLOAT)       \
+  X(KTEMP_OFFS, "tempOffs", INT)         \
   X(KCOUNT, "KCOUNT", UNKNOWN)

--- a/lib/settings/settings.cpp
+++ b/lib/settings/settings.cpp
@@ -98,6 +98,7 @@ void loadPreferences()
   GPS_TX = cfg.getUInt(PKEYS::KGPS_TX, GPS_TX);
   GPS_RX = cfg.getUInt(PKEYS::KGPS_RX, GPS_RX);
   enableWeb = cfg.getBool(PKEYS::KWEB_FILE, enableWeb);
+  tempOffset = cfg.getInt(PKEYS::KTEMP_OFFS,0);
 
   // Default Widgets positions
   #ifdef TDECK_ESP32S3

--- a/lib/settings/settings.cpp
+++ b/lib/settings/settings.cpp
@@ -49,6 +49,7 @@ uint16_t speedPosX = 0;       // Speed widget position X
 uint16_t speedPosY = 0;       // Speed widget position Y
 bool enableWeb = true;        // Enable/disable web file server
 bool showToolBar = false;     // Show Map Toolbar
+int8_t tempOffset = 0;        // BME Temperature offset
 // float batteryMax = 0.0;       // 4.2;      // maximum voltage of battery
 // float batteryMin = 0.0;       // 3.6;      // minimum voltage of battery before shutdown
 

--- a/lib/settings/settings.hpp
+++ b/lib/settings/settings.hpp
@@ -44,6 +44,7 @@ extern uint16_t altitudePosY; // Altitude widget position Y
 extern uint16_t speedPosX;    // Speed widget position X
 extern uint16_t speedPosY;    // Speed widget position Y
 extern bool enableWeb;        // Enable/disable web file server
+extern int8_t tempOffset;     // BME Temperature offset
 
 void loadPreferences();
 void saveMapRotation(bool zoomRotation);


### PR DESCRIPTION
## Description

Add custom settings for temperature offset (+/-)

If BME or other temperature sensor attached, new CLI custom settings it's created to adjust offset

![imagen](https://github.com/user-attachments/assets/072c3384-e9a3-4bac-a544-9d384d018749)

To setup this value in CLI (default value is 0)

``` kset tempOffs value``` 
