### PR TITLE
Coredump partition validation and check

### DIFF
--- a/lib/utils/src/debugUtils.hpp
+++ b/lib/utils/src/debugUtils.hpp
@@ -1,0 +1,25 @@
+#if CORE_DEBUG_LEVEL >= ARDUHAL_LOG_LEVEL_DEBUG
+
+#include "esp_core_dump.h"
+
+void inline checkCoreDumpPartition() {
+  esp_core_dump_init();
+  esp_core_dump_summary_t *summary =
+      static_cast<esp_core_dump_summary_t *>(malloc(sizeof(esp_core_dump_summary_t)));
+  if (summary) {
+    esp_err_t err = esp_core_dump_get_summary(summary);
+    if (err == ESP_OK) {
+      log_i("Getting core dump summary ok.");
+
+    } else {
+      log_e("Getting core dump summary not ok. Error: %d", (int)err);
+      log_e("Probably no coredump present yet.");
+      log_e("esp_core_dump_image_check() = %d", esp_core_dump_image_check());
+    }
+    free(summary);
+  }
+}
+
+#else
+void inline checkCoreDumpPartition() {}
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -69,6 +69,7 @@ build_flags =
 extends = esp32_common
 board = T-Deck
 upload_speed = 921600
+board_build.partitions = default_16MB.csv
 build_flags = 
   ${common.build_flags}
   -DBOARD_HAS_PSRAM

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "gps.hpp"
 #include "storage.hpp"
 #include "tft.hpp"
+#include "debugUtils.hpp"
 
 #ifdef HMC5883L
 #include "compass.hpp"
@@ -81,6 +82,7 @@ void calculateSun()
  */
 void setup()
 {
+  checkCoreDumpPartition();
   gpsMutex = xSemaphoreCreateMutex();
   
   // Force GPIO0 to internal PullUP  during boot (avoid LVGL key read)


### PR DESCRIPTION
## Description

Added basic coredump check utility only for debug versions. This utility need  `espcoredump` command in the system to retrieve `coredump` files and its exception extended info.

## Usage:

```bash
esp-coredump -p /dev/ttyACM0 info_corefile .pio/build/TDECK_ESP32S3/firmware.elf
```
## Related Issues

#261

## Tests

Tested with different hardware and forced panic exceptions and works.

