### PR TITLE
Fix T-Deck board manifiest 

### DIFF
--- a/boards/T-Deck.json
+++ b/boards/T-Deck.json
@@ -7,7 +7,9 @@
     },
     "core": "esp32",
     "extra_flags": [
-      "-DARDUINO_USB_MODE=1",
+      "-DBOARD_HAS_PSRAM",
+      "-DARDUINO_USB_CDC_ON_BOOT=1",
+      "-DARDUINO_USB_MODE=0",
       "-DARDUINO_RUNNING_CORE=1",
       "-DARDUINO_EVENT_RUNNING_CORE=1"
     ],
@@ -18,7 +20,7 @@
     "mcu": "esp32s3",
     "variant": "esp32s3"
   },
-  "connectivity": ["wifi"],
+  "connectivity": ["wifi", "bluetooth", "lora"],
   "debug": {
     "default_tool": "esp-builtin",
     "onboard_tools": ["esp-builtin"],
@@ -30,6 +32,8 @@
     "flash_size": "16MB",
     "maximum_ram_size": 327680,
     "maximum_size": 16777216,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true,
     "require_upload_port": true,
     "speed": 921600
   },

--- a/platformio.ini
+++ b/platformio.ini
@@ -68,15 +68,12 @@ build_flags =
 [env:TDECK_ESP32S3]
 extends = esp32_common
 board = T-Deck
-upload_speed = 921600
 build_flags = 
   ${common.build_flags}
-  -DBOARD_HAS_PSRAM
   -DADC1
   -DBATT_PIN=ADC1_CHANNEL_3
   -DPOWER_SAVE
   -DAT6558D_GPS
-  -DARDUINO_USB_CDC_ON_BOOT=1
 
 [env:ELECROW_ESP32]
 extends = esp32_common


### PR DESCRIPTION
## Description

Seems that the last version of esptool change, and we need this changes in the T-Deck board manifiest to fix upload issues, we need the touch option to reset and wait for the upload port like this:

```bash
Auto-detected: /dev/ttyACM0
Forcing reset using 1200bps open/close on port /dev/ttyACM0
Waiting for the new upload port...
Uploading .pio/build/t-deck-tft/firmware.bin
esptool.py v4.5.1
Serial port /dev/ttyACM0
Connecting...
Chip is ESP32-S3 (revision v0.1)
```

