### PR TITLE
Add 38400 GPS baud option

### DIFF
--- a/lib/gps/gps.cpp
+++ b/lib/gps/gps.cpp
@@ -121,7 +121,7 @@ void buildPcas03(char *out, size_t outSize, uint8_t rateIdx)
  * @brief Init GPS and custom NMEA parsing.
  *
  * @details Initializes the GPS port with the appropriate baud rate and buffer size.
- * 			If a specific baud rate is not set (gpsBaud != 3), it uses the predefined baud rate array.
+ * 			If a specific baud rate is not set (gpsBaud != 4), it uses the predefined baud rate array.
  *			Otherwise, it attempts to auto-detect the baud rate.
  */
 void Gps::init()
@@ -137,7 +137,7 @@ void Gps::init()
 
     gpsPort.setRxBufferSize(2048);
 
-    if (gpsBaud != 3)
+    if (gpsBaud != 4)
         gpsPort.begin(GPS_BAUD[gpsBaud], SERIAL_8N1, GPS_RX, GPS_TX);
     else
     {

--- a/lib/gps/gps.hpp
+++ b/lib/gps/gps.hpp
@@ -40,8 +40,8 @@ extern bool nmea_output_enable;  /**< Enables or disables NMEA output. */
 class Gps;
 extern Gps gps; /**< Global GPS instance */
 
-static const unsigned long GPS_BAUD[] = {4800, 9600, 19200, 0}; /**< Supported GPS baud rates. */
-static const char *GPS_BAUD_PCAS[] = {"$PCAS01,0*1C\r\n", "$PCAS01,1*1D\r\n", "$PCAS01,2*1E\r\n"}; /**< NMEA command strings to set baud rate for PCAS modules. */
+static const unsigned long GPS_BAUD[] = {4800, 9600, 19200, 38400, 0}; /**< Supported GPS baud rates. */
+static const char *GPS_BAUD_PCAS[] = {"$PCAS01,0*1C\r\n", "$PCAS01,1*1D\r\n", "$PCAS01,2*1E\r\n", "$PCAS01,3*1F\r\n"}; /**< NMEA command strings to set baud rate for PCAS modules. */
 static const char *GPS_RATE_PCAS[] = {"$PCAS02,1000*2E\r\n", "$PCAS02,500*1A\r\n", "$PCAS02,250*18\r\n", "$PCAS02,200*1D\r\n", "$PCAS02,100*1E\r\n"}; /**< NMEA command strings to set update rate for PCAS modules. */
 static const uint8_t GPS_RATE_HZ[] = {1, 2, 4, 5, 10}; /**< Update rate in Hz per GPS_RATE_PCAS index. */
 

--- a/lib/gui/src/deviceSettingsScr.cpp
+++ b/lib/gui/src/deviceSettingsScr.cpp
@@ -165,7 +165,7 @@ void createDeviceSettingsScr()
     lv_obj_clear_flag(list, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_set_align(list, LV_ALIGN_OUT_LEFT_BOTTOM);
     dropdown = lv_dropdown_create(list);
-    lv_dropdown_set_options(dropdown, "4800\n9600\n19200\nAUTO");
+    lv_dropdown_set_options(dropdown, "4800\n9600\n19200\n38400\nAUTO");
     lv_dropdown_set_selected(dropdown, gpsBaud);
     lv_obj_t* item = lv_dropdown_get_list(dropdown);
     lv_obj_set_style_bg_color(item, lv_color_hex(objectColor), LV_PART_SELECTED | LV_STATE_CHECKED);

--- a/lib/settings/settings.cpp
+++ b/lib/settings/settings.cpp
@@ -132,7 +132,7 @@ void loadPreferences()
  * @details Saves the GPS baud rate to persistent storage and configures the GPS port
  * 			accordingly. If not using auto baud detection, sends configuration commands
  * 			to the GPS module (AT6558D), resets the port, and sets the new baud rate.
- * 			If using auto baud detection (gpsBaud == 3), attempts to detect baud rate
+ * 			If using auto baud detection (gpsBaud == 4), attempts to detect baud rate
  * 			automatically and reconfigures the port.
  *
  * @param gpsBaud Baud rate index to save and configure
@@ -140,7 +140,7 @@ void loadPreferences()
 void saveGPSBaud(uint16_t gpsBaud)
 {
     cfg.saveShort(PKEYS::KGPS_SPEED, gpsBaud);
-    if (gpsBaud != 3)
+    if (gpsBaud != 4)
     {
         #ifdef AT6558D_GPS
             gpsPort.flush();


### PR DESCRIPTION
## Summary

This PR adds `38400` as a selectable GPS baud rate.

Some T-Deck Plus units with u-blox GNSS modules use 38400 baud by default. The current fixed baud rate list only contains 4800, 9600 and 19200, with AUTO at index 3, so 38400 cannot be selected from the GUI.

## Changes

- Add `38400` to `GPS_BAUD[]`
- Move AUTO baud index from `3` to `4`
- Add `38400` to the GPS Speed dropdown
- Set `gpsBaudDetected` when a fixed baud rate is selected, so the `info` command reports the active baud rate correctly
- Keep AUTO as the default value

## Tested on

- Device: LilyGO T-Deck Plus
- Environment: `TDECK_ESP32S3`
- GPS baud: `38400`
- GPS update rate: `1 Hz`

## Test result

With 38400 selected:

- NMEA parsing works
- `Parse OK` increases continuously
- `CRC Errors` remains `0`
- GNSS gets a 3D fix

## Index mapping after this change

```text
0 = 4800
1 = 9600
2 = 19200
3 = 38400
4 = AUTO