### PR TITLE
fix: clamp trig LUT index to prevent OOB reads on close points

### DIFF
--- a/lib/gps/gps.cpp
+++ b/lib/gps/gps.cpp
@@ -520,7 +520,7 @@ void Gps::simFakeGPS(const TrackVector& trackData, uint16_t speed, uint16_t refr
 
         if (simulationIndex < (int)trackData.size() - 1)
         {
-            const float maxSegmentDist = 5000.0f; // Track gap above this is a cut, not travelled
+            const float maxSegmentDist = SIM_MAX_SEGMENT_DIST; // Track gap above this is a cut, not travelled
 
             // Distance to advance this refresh: speed (km/h) over the elapsed refresh window
             float stepDist = (speed * 1000.0f / 3600.0f) * (refresh / 1000.0f);

--- a/lib/gps/gps.hpp
+++ b/lib/gps/gps.hpp
@@ -153,6 +153,7 @@ class Gps
         *
         */
         const float headAlpha = 0.5f;          /**< Heading smoothing factor, controls how fast heading adapts */
+        static constexpr float SIM_MAX_SEGMENT_DIST = 50000.0f; /**< Track segment (m) above this is treated as a cut, not travelled */
         float smoothedLat = 0.0f;              /**< Interpolated latitude along the current segment */
         float smoothedLon = 0.0f;              /**< Interpolated longitude along the current segment */
         float filteredHeading = 0.0f;          /**< Smoothed heading after filtering */

--- a/lib/utils/src/climbAnalyzer.cpp
+++ b/lib/utils/src/climbAnalyzer.cpp
@@ -207,16 +207,16 @@ void ClimbAnalyzer::clear()
 /**
  * @brief Update climb subjects from current GPS position.
  *
- * @details Runs on Core 1 via the map async callback. In simulation mode uses
- *          simIndex directly; in real GPS mode calls findClosestTrackPoint within
- *          the configured search window. Activates the overlay when within
- *          CLIMB_ANTICIPATION_M of a segment start and keeps it visible until
- *          distRem reaches zero.
+ * @details Runs on Core 1 via the map async callback. Derives the closest track
+ *          point from the current position within the configured search window
+ *          (same path for simulation and real GPS). Activates the overlay when
+ *          within CLIMB_ANTICIPATION_M of a segment start and keeps it visible
+ *          until distRem reaches zero.
  *
  * @param lat      Current latitude.
  * @param lon      Current longitude.
- * @param simMode  True when simulation navigation is active.
- * @param simIndex Current simulation track index.
+ * @param simMode  True when simulation navigation is active (unused).
+ * @param simIndex Current simulation track index (unused).
  * @param track    Loaded track points with ele and accumDist populated.
  */
 void ClimbAnalyzer::updatePosition(float lat, float lon, bool simMode, int simIndex, const TrackVector& track)
@@ -224,9 +224,9 @@ void ClimbAnalyzer::updatePosition(float lat, float lon, bool simMode, int simIn
     if (track.empty() || !hasClimbs())
         return;
 
-    int idx = simMode
-              ? simIndex
-              : findClosestTrackPoint(lat, lon, track, lastTrackIdx);
+    int idx = findClosestTrackPoint(lat, lon, track, lastTrackIdx);
+    (void)simMode;
+    (void)simIndex;
     if (idx < 0)
         return;
 

--- a/lib/utils/src/gpsMath.hpp
+++ b/lib/utils/src/gpsMath.hpp
@@ -80,6 +80,8 @@ static inline __attribute__((always_inline)) float sinLUT(float rad)
 
     float index = rad / LUT_RES;
     int idx_low = (int)index;
+    if (idx_low >= LUT_SIZE)
+        idx_low = LUT_SIZE - 1;
     int idx_high = (idx_low + 1) % LUT_SIZE;
 
     float frac = index - idx_low;
@@ -107,6 +109,8 @@ static inline __attribute__((always_inline)) float cosLUT(float rad)
 
 	float index = rad / (float)LUT_RES;
 	int idx_low = (int)index;
+	if (idx_low >= LUT_SIZE)
+		idx_low = LUT_SIZE - 1;
 	int idx_high = (idx_low + 1) % LUT_SIZE;
 
 	float frac = index - idx_low;


### PR DESCRIPTION
sinLUT/cosLUT could index beyond LUT_SIZE when a small angle rounded to 2*PI in float32, making calcDist/calcCourse return garbage for points <~3m apart. This broke simFakeGPS (jumps/ stalls on dense tracks) and corrupted close-range navigation distances, track accumDist and grades.

Raise sim track-cut threshold to 50km and derive climb subjects from the interpolated position.

